### PR TITLE
Fix get user

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -1,7 +1,8 @@
 /****************
  * IMPORTS
  */
-
+var https = require('https');
+var { XMLParser } = require('fast-xml-parser');
 var util = require('util');
 var OAuth2Strategy = require('passport-oauth2');
 var InternalOAuthError = require('passport-oauth2').InternalOAuthError;
@@ -18,9 +19,10 @@ var InternalOAuthError = require('passport-oauth2').InternalOAuthError;
  * credentials are not valid.  If an exception occured, `err` should be set.
  *
  * Options:
- *   - `clientId`      	your Microsoft application's client id
- *   - `clientSecret`  	your Microsoft application's client secret
- *   - `callbackURL`   	URL to which Microsoft will redirect the user after granting authorization in your Microsoft Application
+ *   - `clientId`       your Microsoft application's client id
+ *   - `clientSecret`   your Microsoft application's client secret
+ *   - `DeveloperToken` the developer token from Microsoft Ads
+ *   - `callbackURL`    URL to which Microsoft will redirect the user after granting authorization in your Microsoft Application
  *
  * Examples:
  *
@@ -29,6 +31,7 @@ var InternalOAuthError = require('passport-oauth2').InternalOAuthError;
  *     passport.use(new MicrosoftStrategy({
  *         clientID: '123-456-789',
  *         clientSecret: 'shhh-its-a-secret'
+ *         DeveloperToken: 'shhh-its-also-a-secret'
  *         callbackURL: 'https://www.example.net/auth/microsoft/callback'
  *       },
  *       function(accessToken, refreshToken, profile, done) {
@@ -46,13 +49,19 @@ var InternalOAuthError = require('passport-oauth2').InternalOAuthError;
 function MicrosoftStrategy(options, verify) {
   options = options || {};
   const tenant = options.tenant || 'common';
-  options.authorizationURL = options.authorizationURL || `https://login.microsoftonline.com/${tenant}/oauth2/v2.0/authorize`;
-  options.tokenURL = options.tokenURL || `https://login.microsoftonline.com/${tenant}/oauth2/v2.0/token`;
+  options.authorizationURL =
+    options.authorizationURL ||
+    `https://login.microsoftonline.com/${tenant}/oauth2/v2.0/authorize`;
+  options.tokenURL =
+    options.tokenURL ||
+    `https://login.microsoftonline.com/${tenant}/oauth2/v2.0/token`;
   options.scopeSeparator = options.scopeSeparator || ' ';
   options.customHeaders = options.customHeaders || {};
+  options.developerToken = options.developerToken || '';
 
   OAuth2Strategy.call(this, options, verify);
   this.name = 'microsoft';
+  this.developerToken = options.developerToken;
 }
 
 /**
@@ -71,57 +80,133 @@ util.inherits(MicrosoftStrategy, OAuth2Strategy);
  *   - etc..
  *
  * @param {String} accessToken
+ * @param {String} developerToken
  * @param {Function} done
  * @api protected
  */
 
-MicrosoftStrategy.prototype.authorizationParams = function(options) {
+MicrosoftStrategy.prototype.authorizationParams = function (options) {
   var params = {};
-  
-  ['locale', 'display', 'prompt', 'login_hint', 'domain_hint'].forEach(function(name) {
-    if (options[name]) {
-      params[name] = options[name];
+
+  ['locale', 'display', 'prompt', 'login_hint', 'domain_hint'].forEach(
+    function (name) {
+      if (options[name]) {
+        params[name] = options[name];
+      }
     }
-  });
+  );
 
   return params;
 };
 
 MicrosoftStrategy.prototype.userProfile = function (accessToken, done) {
+  var soapRequest = this.constructSoapRequest(accessToken);
 
-  this._oauth2.useAuthorizationHeaderforGET(true);
-  this._oauth2.get(
-    'https://graph.microsoft.com/v1.0/me/',
-    accessToken,
-    // eslint-disable-next-line no-unused-vars
-    function (err, body, res) {
+  var requestOptions = {
+    hostname: 'clientcenter.api.bingads.microsoft.com',
+    path: '/Api/CustomerManagement/v13/CustomerManagementService.svc',
+    method: 'POST',
+    headers: {
+      'Content-Type': 'text/xml; charset=utf-8',
+      SOAPAction: 'GetUser',
+    },
+  };
 
-      if (err) {
-        return done(new InternalOAuthError('failed to fetch user profile', err));
-      }
+  var xmlParserOptions = {
+    attributeNamePrefix: '',
+    ignoreNameSpace: true,
+    allowBooleanAttributes: true,
+    trimValues: true,
+  };
+
+  var req = https.request(requestOptions, function (res) {
+    var responseBody = '';
+
+    res.setEncoding('utf-8');
+    res.on('data', function (chunk) {
+      responseBody += chunk;
+    });
+
+    res.on('end', function () {
+
+      const parser = new XMLParser();
+      let json;
       try {
-        var json = JSON.parse(body);
+        json = parser.parse(responseBody, xmlParserOptions);
+      } catch (parseErr) {
+        return done(
+          new InternalOAuthError('Error parsing SOAP response', parseErr)
+        );
+      }
+
+      try {
+        const body = json['s:Envelope']['s:Body'];
+        if (body['s:Fault']) {
+          const fault = body['s:Fault'];
+          let errorMessage =
+            fault.faultstring || 'Error in response of SOAP request';
+
+          if (
+            fault.detail &&
+            fault.detail.AdApiFaultDetail &&
+            fault.detail.AdApiFaultDetail.Errors &&
+            fault.detail.AdApiFaultDetail.Errors.AdApiError
+          ) {
+            errorMessage =
+              fault.detail.AdApiFaultDetail.Errors.AdApiError.Message ||
+              errorMessage;
+          }
+
+          throw new Error(errorMessage);
+        }
+        var user = body.GetUserResponse.User;
 
         var profile = {
           provider: 'microsoft',
-          name: {}
+          name: {
+            givenName: user['a:Name']['a:FirstName'],
+            familyName: user['a:Name']['a:LastName'],
+          },
+          emails: [{ type: 'work', value: user['a:ContactInfo']['a:Email'] }],
+          id: user['a:Id'],
+          displayName:
+            user['a:Name']['a:FirstName'] + ' ' + user['a:Name']['a:LastName'],
+          _raw: responseBody,
+          _json: json,
         };
-        profile.id = json.id;
-        profile.displayName = json.displayName;
-        profile.name.familyName = json.surname;
-        profile.name.givenName = json.givenName;
-        profile.emails = [{ type: 'work', value: json.mail || json.userPrincipalName }];
 
-        profile._raw = body;
-        profile._json = json;
 
         done(null, profile);
+      } catch (e) {
+        done(new InternalOAuthError('Failed fetch user profile', e));
       }
-      catch (e) {
-        done(e);
-      }
-    }
-  );
+    });
+  });
+
+  req.on('error', function (e) {
+    done(
+      new InternalOAuthError('Failed to fetch user profile via SOAP request', e)
+    );
+  });
+
+  req.write(soapRequest);
+  req.end();
+};
+
+MicrosoftStrategy.prototype.constructSoapRequest = function (accessToken) {
+  return `<?xml version='1.0' encoding='utf-8'?>
+       <s:Envelope xmlns:s='http://schemas.xmlsoap.org/soap/envelope/'>
+       <s:Header>
+           <h:ApplicationToken i:nil='true' xmlns:h='https://bingads.microsoft.com/Customer/v13' xmlns:i='http://www.w3.org/2001/XMLSchema-instance' />
+           <h:AuthenticationToken xmlns:h='https://bingads.microsoft.com/Customer/v13'>${accessToken}</h:AuthenticationToken>
+           <h:DeveloperToken xmlns:h='https://bingads.microsoft.com/Customer/v13'>${this.developerToken}</h:DeveloperToken>
+       </s:Header>
+       <s:Body>
+           <GetUserRequest xmlns='https://bingads.microsoft.com/Customer/v13'>
+           <UserId i:nil='true' xmlns:i='http://www.w3.org/2001/XMLSchema-instance' />
+           </GetUserRequest>
+       </s:Body>
+       </s:Envelope>`;
 };
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "passport-microsoft",
       "version": "1.0.0",
       "dependencies": {
+        "fast-xml-parser": "^4.2.7",
         "passport-oauth2": "1.6.1"
       },
       "devDependencies": {
@@ -683,6 +684,27 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "node_modules/fast-xml-parser": {
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.7.tgz",
+      "integrity": "sha512-J8r6BriSLO1uj2miOk1NW0YVm8AGOOu3Si2HQp/cSmo6EA4m3fcwu2WKjJ4RK9wMLBtg69y1kS8baDiQBR41Ig==",
+      "funding": [
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -1158,9 +1180,9 @@
       "dev": true
     },
     "node_modules/json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "dev": true,
       "dependencies": {
         "minimist": "^1.2.0"
@@ -1506,9 +1528,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -1607,6 +1629,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -1749,9 +1776,9 @@
       }
     },
     "node_modules/word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   ],
   "main": "./lib/",
   "dependencies": {
+    "fast-xml-parser": "^4.2.7",
     "passport-oauth2": "1.6.1"
   },
   "engines": {


### PR DESCRIPTION
This PR fixes the get user profile. It does so by changing to a SOAP request when fetching the user profile.
Some points to note:
1) Adds a requirement of an XML parser package
2) Adds the need to supply the dev token to the passport-microsoft implementation in Alvie, through the config

This is the first time I've worked with SOAP requests, so should prob go through that logic a bit thoroughly. However I tested both
1) Happy path
Returns the correct user object
2) Unhappy path
Makes the following error:
```
error:  Error: Authentication failed. Either supplied credentials are invalid or the account is inactive
    at IncomingMessage.<anonymous> (/Users/juliusantoniobladt/repos/precis-user-platform/ui/node_modules/@precis-digital/passport-microsoft/lib/strategy.js:154:17)
    at IncomingMessage.emit (node:events:525:35)
    at endReadableNT (node:internal/streams/readable:1359:12)
    at process.processTicksAndRejections (node:internal/process/task_queues:82:21)
```
