### PR TITLE
user_id to string

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -168,7 +168,7 @@ MicrosoftStrategy.prototype.userProfile = function (accessToken, done) {
             familyName: user['a:Name']['a:LastName'],
           },
           emails: [{ type: 'work', value: user['a:ContactInfo']['a:Email'] }],
-          id: user['a:Id'],
+          id: user['a:Id'].toString(),
           displayName:
             user['a:Name']['a:FirstName'] + ' ' + user['a:Name']['a:LastName'],
           _raw: responseBody,


### PR DESCRIPTION
Changing the type from number to string in this repo, to avoid having to loosen the types of the "id" within Alvie