### PR TITLE
Update fast-xml-parser dependency to version 4.5.4 in package.json an…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "passport-microsoft",
       "version": "1.0.0",
       "dependencies": {
-        "fast-xml-parser": "^4.2.7",
+        "fast-xml-parser": "^4.5.4",
         "passport-oauth2": "1.6.1"
       },
       "devDependencies": {
@@ -685,19 +685,16 @@
       "dev": true
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.7.tgz",
-      "integrity": "sha512-J8r6BriSLO1uj2miOk1NW0YVm8AGOOu3Si2HQp/cSmo6EA4m3fcwu2WKjJ4RK9wMLBtg69y1kS8baDiQBR41Ig==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.4.tgz",
+      "integrity": "sha512-jE8ugADnYOBsu1uaoayVl1tVKAMNOXyjwvv2U6udEA2ORBhDooJDWoGxTkhd4Qn4yh59JVVt/pKXtjPwx9OguQ==",
       "funding": [
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/naturalintelligence"
-        },
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "strnum": "^1.0.5"
       },

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   ],
   "main": "./lib/",
   "dependencies": {
-    "fast-xml-parser": "^4.2.7",
+    "fast-xml-parser": "^4.5.4",
     "passport-oauth2": "1.6.1"
   },
   "engines": {


### PR DESCRIPTION
https://github.com/Precis-Digital/precis-user-platform/security/dependabot/575


## Security
- **4.5.4** fixes the entity encoding bypass / regex injection in DOCTYPE entity names (e.g. #575). Affected: `>= 4.1.3, < 4.5.4`. Use **4.5.4** or later.
## Changelog
| Version | Date       | Changes |
|---------|------------|--------|
| 4.5.4   | 2025-02-27 | Update strnum (parsing fixes); security fix for entity/regex issue |
| 4.5.3   | 2025-02-21 | Update strnum (parsing fixes) |
| 4.5.2   | 2025-02-18 | Null CDATA (#701); leaf-node perf (#707); CLI full JSON (#710) |
| 4.5.1   | 2024-12-15 | v5 empty tag key (#697); entity parsing in strict mode (#699) |
| 4.5.0   | 2024-09-03 | `ignoreAttributes` supports function and array of strings/regex (#666) |
| 4.4.1   | 2024-07-28 | oneListGroup/attributesGroupName (#634, #662); v5 currency length |
| 4.4.0   | 2024-05-18 | Self-closing stop node (#654); validator (#647); typings (#582) |
| 4.3.6   | 2024-03-16 | HTML numeric entities (#645) |
| 4.3.5   | 2024-02-24 | v5 code (experimental) |
| 4.3.4   | 2024-01-10 | Don’t escape entities in CDATA (#633) |
| 4.3.3   | 2024-01-10 | Remove unnecessary regex |
| 4.3.2   | 2023-10-02 | Fix `hasOwnProperty` when input is null (#613) |
| 4.3.1   | 2023-09-24 | Revert generic typings |
| 4.3.0   | 2023-09-20 | stopNodes + removeNSPrefix (#607–608); Object.prototype (#610); typings |
| 4.2.7   | 2023-07-30 | Builder text node (#589); null/undefined attributes (#585, #598) |
## Recommendation
Set `fast-xml-parser` to **^4.5.4** in `package.json` and run `npm install`.